### PR TITLE
Handle fractional-second ISO8601 strings in `@DateCoding`

### DIFF
--- a/Sources/ReerCodable/DateCodingStrategy.swift
+++ b/Sources/ReerCodable/DateCodingStrategy.swift
@@ -50,4 +50,10 @@ public enum DateCodingStrategy {
         formatter.formatOptions = .withInternetDateTime
         return formatter
     }()
+    
+    nonisolated(unsafe) static let iso8601FractionalSecondsFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
 }

--- a/Sources/ReerCodable/KeyedDecodingContainer+Extensions.swift
+++ b/Sources/ReerCodable/KeyedDecodingContainer+Extensions.swift
@@ -177,7 +177,11 @@ extension KeyedDecodingContainer where K == AnyCodingKey {
             }
         case .iso8601:
             return try decodeDateValue(type: type, keys: keys) { (rawValue: String) in
-                guard let date = DateCodingStrategy.iso8601Formatter.date(from: rawValue) else {
+                let date =
+                    DateCodingStrategy.iso8601Formatter.date(from: rawValue)
+                    ?? DateCodingStrategy.iso8601FractionalSecondsFormatter.date(from: rawValue)
+                
+                guard let date else {
                     throw ReerCodableError(text: "Decode date with iso8601 string failed for keys: \(keys)")
                 }
                 return date

--- a/Tests/ReerCodableTests/DateCodingTests.swift
+++ b/Tests/ReerCodableTests/DateCodingTests.swift
@@ -22,13 +22,16 @@ class DateModel {
     @DateCoding(.iso8601)
     var date5: Date
     
-    @DateCoding(.formatted(Self.formatter))
+    @DateCoding(.iso8601)
     var date6: Date
+    
+    @DateCoding(.formatted(Self.formatter))
+    var date7: Date
     
     static let formatter: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
+        dateFormatter.dateFormat = "yyyy'Year'MM'-Month'dd'*Day 'HH'h'mm'm'ss's'"
         dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
         return dateFormatter
     }()
@@ -41,7 +44,8 @@ let jsonData4 = """
     "date3": 1731585275,
     "date4": 1731585275944,
     "date5": "2024-12-10T00:00:00Z",
-    "date6": "2024-12-10T00:00:00.000"
+    "date6": "2025-04-17T00:00:00.000Z",
+    "date7": "2024Year12-Month10*Day 00h00m00s"
 }
 """.data(using: .utf8)!
 
@@ -55,7 +59,8 @@ extension TestReerCodable {
         #expect(model.date3.timeIntervalSince1970 == 1731585275)
         #expect(model.date4.timeIntervalSince1970 * 1000 == 1731585275944)
         #expect(model.date5.timeIntervalSince1970 == 1733788800.0)
-        #expect(model.date6.timeIntervalSince1970 == 1733788800.0)
+        #expect(model.date6.timeIntervalSince1970 == 1744848000.0)
+        #expect(model.date7.timeIntervalSince1970 == 1733788800.0)
         
         // Encode
         let modelData = try JSONEncoder().encode(model)
@@ -68,6 +73,7 @@ extension TestReerCodable {
         #expect(dict.int("date3") == 1731585275)
         #expect(dict.double("date4") == 1731585275944)
         #expect(dict.string("date5") == "2024-12-10T00:00:00Z")
-        #expect(dict.string("date6") == "2024-12-10T00:00:00.000")
+        #expect(dict.string("date6") == "2025-04-17T00:00:00Z")
+        #expect(dict.string("date7") == "2024Year12-Month10*Day 00h00m00s")
     }
 }


### PR DESCRIPTION
- Added a dedicated ISO8601 formatter that accepts fractional seconds and fall back to it during decoding
- Expanded DateCodingTests with both the fractional ISO sample and a deliberately odd custom formatter string to keep round-trip coverage strong