### PR TITLE
Update `swift-syntax` to 603.0.x

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "7e1ce10f334fdd05711290248172cd9eac19840d042c7e69794acb65814ca411",
+  "originHash" : "9bd1edec01a1c1d3b8ab0061a6df60b5ac709b38ccd6dbdb982daa4571c28a04",
   "pins" : [
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
+        "version" : "603.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", from: "603.0.0"),
     ],
     targets: [
         .macro(

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ iOS 13.0+, macOS 10.15+, tvOS 13.0+, visionOS 1.0+, watchOS 6.0+
 
 Swift 5.10+
 
-swift-syntax 600.0.0+
+swift-syntax 603.0.0+
 
 # Installation
 <details>

--- a/README_CN.md
+++ b/README_CN.md
@@ -63,7 +63,7 @@ iOS 13.0+, macOS 10.15+, tvOS 13.0+, visionOS 1.0+, watchOS 6.0+
 
 Swift 5.10+
 
-swift-syntax 600.0.0+
+swift-syntax 603.0.0+
 
 # 安装
 <details>


### PR DESCRIPTION
Update `swift-syntax` to version 603.0.x . Linked to the issue https://github.com/reers/ReerCodable/issues/43